### PR TITLE
Refactoring of Vulkan API Abstraction Part 1

### DIFF
--- a/WolfRenderer/WolfRenderer/WolfRenderer.vcxproj
+++ b/WolfRenderer/WolfRenderer/WolfRenderer.vcxproj
@@ -158,6 +158,7 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="src\renderer\Vulkan\v_Instance\v_Instance.h" />
     <ClInclude Include="src\Window.h" />
     <ClInclude Include="src\WolfRenderer.h" />
     <ClInclude Include="src\core\Application.h" />
@@ -212,6 +213,7 @@
     <ClCompile Include="src\renderer\Vulkan\v_Devices\v_QueueFamilies\v_QueueFamilies.cpp" />
     <ClCompile Include="src\renderer\Vulkan\v_Devices\v_SwapChain\v_SwapChain.cpp" />
     <ClCompile Include="src\renderer\Vulkan\v_Devices\v_SyncObjects\v_SyncObjects.cpp" />
+    <ClCompile Include="src\renderer\Vulkan\v_Instance\v_Instance.cpp" />
     <ClCompile Include="src\renderer\Vulkan\v_Pipeline\v_Pipeline.cpp" />
     <ClCompile Include="src\renderer\Vulkan\v_Shaders\v_Shaders.cpp" />
     <ClCompile Include="src\renderer\Vulkan\v_Surface\v_Surface.cpp" />

--- a/WolfRenderer/WolfRenderer/WolfRenderer.vcxproj.filters
+++ b/WolfRenderer/WolfRenderer/WolfRenderer.vcxproj.filters
@@ -144,6 +144,7 @@
     <ClInclude Include="src\renderer\Vulkan\v_Surface\v_Surface.h">
       <Filter>renderer\Vulkan\v_Surface</Filter>
     </ClInclude>
+    <ClInclude Include="src\renderer\Vulkan\v_Instance\v_Instance.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\core\src\Application.cpp">
@@ -216,5 +217,6 @@
     <ClCompile Include="src\renderer\Vulkan\v_Surface\v_Surface.cpp">
       <Filter>renderer\Vulkan\v_Surface</Filter>
     </ClCompile>
+    <ClCompile Include="src\renderer\Vulkan\v_Instance\v_Instance.cpp" />
   </ItemGroup>
 </Project>

--- a/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Debugger/v_Debugger.h
+++ b/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Debugger/v_Debugger.h
@@ -10,9 +10,9 @@ namespace WolfRenderer
 	class WLFR_API v_Debugger : public v_ValidationLayers
 	{
 	
-	
+		friend class v_Instance; 
 	public: 
-		v_Debugger();
+		v_Debugger(const VkInstance& vulkanInstance, bool isInstanceCreated, std::mutex& instanceCreationStatus, std::condition_variable& instanceCreationSuccessful);
 
 		virtual ~v_Debugger() override;
 
@@ -21,59 +21,45 @@ namespace WolfRenderer
 
 		void setupDebugger(VkInstance instance, VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo, VkDebugUtilsMessengerEXT* debugMessHandle);
 
-		void destroyDebugger(VkInstance instance);
+		void destroyDebugger(VkInstance instance, VkDebugUtilsMessengerEXT debugMessenger);
 
-
-		//creates our debug extension object, implement into Vulkan class 
-		VkResult CreateDebugUtilsMessengerEXT(VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo, VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pDebugMessenger)
-		{
-			auto func = (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT");
-			if (func != nullptr) {
-				return func(instance, pCreateInfo, pAllocator, pDebugMessenger);
-			}
-			else {
-				return VK_ERROR_EXTENSION_NOT_PRESENT;
-			}
-
-		}
-
-		//destroys vulkan debugger handle 
-		static void DestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT debugMessenger, const VkAllocationCallbacks* pAllocator) {
-			auto func = (PFN_vkDestroyDebugUtilsMessengerEXT)vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT");
-			if (func != nullptr) {
-				func(instance, debugMessenger, pAllocator);
-			}
-			
-		}
-
-	    VkDebugUtilsMessengerCreateInfoEXT getDebuggerCreateInfo() const { return debuggerCreateInfo; }
-		VkDebugUtilsMessengerEXT getDebugMessenger() const { return debugMessenger; }
-
-		VkDebugUtilsMessengerEXT* getDebugMessengerPtr()  { return &debugMessenger; }
-
-        VkDebugUtilsMessengerCreateInfoEXT debuggerCreateInfo; 
-	private:
-
-	    VkDebugUtilsMessengerEXT debugMessenger;
 		
 
+    //**Vulkan debugger object creation and destruction functions
+	public:
+		//creates our debug extension object, implement into Vulkan class 
+		VkResult CreateDebugUtilsMessengerEXT(VkInstance instance, 
+			                                  const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo, 
+			                                  VkAllocationCallbacks* pAllocator, 
+			                                  VkDebugUtilsMessengerEXT* pDebugMessenger);
 
+		//destroys vulkan debugger handle 
+		static void DestroyDebugUtilsMessengerEXT(VkInstance instance, 
+			                                      VkDebugUtilsMessengerEXT debugMessenger, 
+			                                      const VkAllocationCallbacks* pAllocator);
 
 		static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
 			VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
 			VkDebugUtilsMessageTypeFlagsEXT messageType,
 			const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
-			void* pUserData)
-		{
-			
-			//TODO: implement message into event system 
-			if (messageSeverity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
-			{
-				std::cerr << "validation layer: " << pCallbackData->pMessage << std::endl;
-			}
+			void* pUserData);
 
-			return VK_FALSE; 
-			}
+
+	//**GETTERS
+	public:
+	    VkDebugUtilsMessengerCreateInfoEXT getCreateInfo() const { return m_DebuggerCreateInfo; }
+		VkDebugUtilsMessengerCreateInfoEXT* getCreateInfoPtr()  { return &m_DebuggerCreateInfo; }
+		VkDebugUtilsMessengerEXT getDebugMessenger() const { return m_DebugMessenger; }
+
+		VkDebugUtilsMessengerEXT* getDebugMessengerPtr()  { return &m_DebugMessenger; }
+
+    //MEMBERS   
+	private:
+
+        VkDebugUtilsMessengerCreateInfoEXT m_DebuggerCreateInfo; 
+	    VkDebugUtilsMessengerEXT m_DebugMessenger;
+		
+
 
 
 

--- a/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Debugger/v_ValidationLayers.cpp
+++ b/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Debugger/v_ValidationLayers.cpp
@@ -11,23 +11,39 @@
 
 namespace WolfRenderer
 {
-#ifdef WLFR_DEBUG
+
 	v_ValidationLayers::v_ValidationLayers()
 	{
-		this->enableLayers = true;
-		this->validationLayers.push_back("VK_LAYER_KHRONOS_validation");
-		checkSupport();
+
 	}
-#else
-	v_ValidationLayers::v_ValidationLayers()
-	{
-		this->enableLayers = false; 
-	}
-#endif
+
+
 
 	v_ValidationLayers::~v_ValidationLayers()
 	{
+		checkSupport();
+	}
 
+	bool v_ValidationLayers::isValidationEnabled()
+	{
+		if (WLFR_DEBUG && validationLayersChecked == 0)
+		{
+			enableLayers = true; 
+			m_ValidationLayers.push_back("VK_LAYER_KHRONOS_validation");
+			validationLayersChecked++; 
+			return enableLayers; 
+		}
+		else if (!WLFR_DEBUG && validationLayersChecked == 0)
+		{
+			enableLayers = false; 
+			validationLayersChecked++; 
+			return enableLayers;
+		}
+		else
+		{
+            return enableLayers; 
+		}
+		
 	}
 
 	bool v_ValidationLayers::checkSupport()
@@ -39,7 +55,7 @@ namespace WolfRenderer
 
 		vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
 
-		for (const char* layerName : validationLayers) {
+		for (const char* layerName : m_ValidationLayers) {
 			bool layerFound = false;
 
 			for (const auto& layerProperties : availableLayers) {

--- a/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Debugger/v_ValidationLayers.h
+++ b/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Debugger/v_ValidationLayers.h
@@ -19,11 +19,10 @@ namespace WolfRenderer
 
 	public:	
 
-		uint32_t getEnabledLayerCount() { return validationLayers.size(); }
-		const char** ptrToValidationLayers() { return validationLayers.data(); }
+		uint32_t getEnabledLayerCount() { return m_ValidationLayers.size(); }
+		const char** ptrToValidationLayers() { return m_ValidationLayers.data(); }
 
-		bool enableLayers;
-		bool isValidationEnabled() { return enableLayers; }
+		bool isValidationEnabled();
 		bool checkSupport();
 
 	protected:
@@ -32,14 +31,14 @@ namespace WolfRenderer
 
 	private:
 
-
 		// TODO: add event dispatcher for Vulkan Events! Validation Layers, notifications, etc. 
 		// TODO: cleanup struct establishing functions
 		
 
 	private:
-		std::vector<const char*> validationLayers;
-
+		bool enableLayers;
+		std::vector<const char*> m_ValidationLayers;
+		int validationLayersChecked = 0; 
 
 	};
 }

--- a/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Devices/v_Devices.h
+++ b/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Devices/v_Devices.h
@@ -27,36 +27,41 @@ namespace WolfRenderer
 		void selectPhysicalDevice();
 		void initialize (VkInstance instance, SDL_Window* window, v_Debugger& theDebugger, VkSurfaceKHR theSurface);
 		void destroyLogicalDevice();
-		VkFence* getFencePtr(int& currentFrame)  { return syncObjects.getPtrToFences(currentFrame); }
+		VkFence* getFencePtr(int& currentFrame)  { return m_SyncObjects.getPtrToFences(currentFrame); }
 
+	//**GETTERS
 	public:
-	    VkDevice getLogicalDevice() const { return logicalDevice; }
-		VkSwapchainKHR getSwapchain() const { return swapChain.getSwapchainHandle(); }
-		v_SwapChain swapChainInterface() const { return swapChain; }
-        VkCommandBuffer getCommandBuffer(int& currentFrame) const { return  commandBuffer.getCommandBufferHandle(currentFrame); }
-		v_QueueFamilies queueFamilyInterface() const { return queueFamilies; }
-		v_ImageViews imageViewInterface() const { return imageViews; }
-		v_Framebuffer frameBufferInterface() const { return framebuffer; }
-		v_Pipeline getGraphicsPipeline() const { return graphicsPipeline; }
+	    VkDevice getLogicalDevice() const { return m_LogicalDevice; }
+
+
+		VkSwapchainKHR getSwapchain() const { return m_SwapChain.getSwapchainHandle(); }
+
+		//TODO: MOVE TO VULKAN FILE!
+		v_SwapChain swapChainInterface() const { return m_SwapChain; }
+        VkCommandBuffer getCommandBuffer(int& currentFrame) const { return  m_CommandBuffer.getCommandBufferHandle(currentFrame); }
+		v_QueueFamilies queueFamilyInterface() const { return m_QueueFamilies; }
+		v_ImageViews imageViewInterface() const { return m_ImageViews; }
+		v_Framebuffer frameBufferInterface() const { return m_Framebuffer; }
+		v_Pipeline getGraphicsPipeline() const { return m_GraphicsPipeline; }
 	public:	
 		void draw(const uint32_t& imageIndex, int& currentFrame);
 
 //TODO: MAKE BETTER INTERFACE WITH LESS SYNTAX
 //functions to interface with Vulkan Singleton
 	public:
-		VkSemaphore getImageSemaphore(int& currentFrame) const { return syncObjects.getImageSemaphore(currentFrame); }
-		VkSemaphore getRenderFinishedSemaphore(int& currentFrame) const { return syncObjects.getRenderFinishedSemaphore(currentFrame); }
-		VkFence getInFlightFence(int& currentFrame) const { return syncObjects.getInFlightFence(currentFrame); }
-		void recordCommandBuffer(int& currentFrame) { commandBuffer.recordCommandBuffer(logicalDevice, graphicsPipeline.getRenderPass(), framebuffer.getFrameBuffers(), swapChain.getSwapChainImageExtent(), graphicsPipeline.getGraphicsPipeline(), 0, graphicsPipeline.getViewport(), graphicsPipeline.getScissor(), currentFrame); }
+		VkSemaphore getImageSemaphore(int& currentFrame) const { return m_SyncObjects.getImageSemaphore(currentFrame); }
+		VkSemaphore getRenderFinishedSemaphore(int& currentFrame) const { return m_SyncObjects.getRenderFinishedSemaphore(currentFrame); }
+		VkFence getInFlightFence(int& currentFrame) const { return m_SyncObjects.getInFlightFence(currentFrame); }
+		void recordCommandBuffer(int& currentFrame) { m_CommandBuffer.recordCommandBuffer(m_LogicalDevice, m_GraphicsPipeline.getRenderPass(), m_Framebuffer.getFrameBuffers(), m_SwapChain.getSwapChainImageExtent(), m_GraphicsPipeline.getGraphicsPipeline(), 0, m_GraphicsPipeline.getViewport(), m_GraphicsPipeline.getScissor(), currentFrame); }
 //**Physical Device members and functions
 	private:
-		VkPhysicalDevice physicalDevice = VK_NULL_HANDLE; 
-		uint32_t physicalDeviceCount; 
-		std::vector<VkPhysicalDevice> availablePhysicalDevices;
-		VkPhysicalDeviceProperties physicalDeviceProperties; 
-		VkPhysicalDeviceFeatures physicalDeviceFeatures; 
+		VkPhysicalDevice m_PhysicalDevice = VK_NULL_HANDLE; 
+		uint32_t m_PhysicalDeviceCount; 
+		std::vector<VkPhysicalDevice> m_AvailablePhysicalDevices;
+		VkPhysicalDeviceProperties m_PhysicalDeviceProperties; 
+		VkPhysicalDeviceFeatures m_PhysicalDeviceFeatures; 
 
-
+//**Physical Device selection functions
 	private:
 		std::vector<VkPhysicalDevice> locatePhysicalDevices(VkInstance instance);
 		int ratePhysicalDevice(VkPhysicalDevice device);
@@ -64,21 +69,21 @@ namespace WolfRenderer
 
 
 //**Misc. classes to interact with devices
+//TODO: Move setup to Vulkan class 
 	private:
-		v_QueueFamilies queueFamilies;
-		v_SwapChain swapChain; 
-		v_Pipeline graphicsPipeline;	 
-		v_Framebuffer framebuffer; 
-		v_ImageViews imageViews; 
+		v_QueueFamilies m_QueueFamilies;
+		v_SwapChain m_SwapChain; 
+		v_Pipeline m_GraphicsPipeline;	 
+		v_Framebuffer m_Framebuffer; 
+		v_ImageViews m_ImageViews; 
 
-
-		v_CommandPool commandPool; 
-		v_CommandBuffer commandBuffer;
-		v_SyncObjects syncObjects;
+		v_CommandPool m_CommandPool; 
+		v_CommandBuffer m_CommandBuffer;
+		v_SyncObjects m_SyncObjects;
 
 //**Logical Device members and functions
 	private:
-		VkDevice logicalDevice;
+		VkDevice m_LogicalDevice;
 	private:
 		void createLogicalDevice(v_Debugger& theDebugger);
 

--- a/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Instance/v_Instance.cpp
+++ b/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Instance/v_Instance.cpp
@@ -1,0 +1,124 @@
+#include "pch.h"
+#include "v_Instance.h"
+
+#include <SDL3/SDL_Vulkan.h>
+
+
+
+
+namespace WolfRenderer
+{
+	v_Instance::v_Instance(v_Debugger& debugger, std::mutex& instanceCreationStatus, std::condition_variable& instanceCreationSuccessful)
+	{
+		std::lock_guard<std::mutex> lk(instanceCreationStatus); 
+		this->m_AvailableExtensions = getAvailableExtensions();
+		this->m_RequiredExtensionNames = getRequiredExtensions(debugger.isValidationEnabled());
+		this->appInfo = inputApplcationInfo(); 
+		createInstance(debugger);
+		instanceCreated = true; 
+		instanceCreationSuccessful.notify_one();
+	}
+
+	v_Instance::~v_Instance()
+	{
+
+	}
+
+	VkApplicationInfo v_Instance::inputApplcationInfo()
+	{
+		appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+		appInfo.pApplicationName = "Sandbox";
+		appInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+		appInfo.pEngineName = "WolfRenderer";
+		appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+		appInfo.apiVersion = VK_MAKE_API_VERSION(0, 1, 3, 261.1);
+
+		return appInfo; 
+	}
+
+	void v_Instance::createInstance(v_Debugger& debugger)
+	{
+
+		VkInstanceCreateInfo createInfo{};
+		createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+		createInfo.pApplicationInfo = &appInfo;
+
+		debugger.inputDebugMessengerInfo();
+
+		createInfo.enabledExtensionCount = m_RequiredExtensionNames.size();
+		createInfo.ppEnabledExtensionNames = m_RequiredExtensionNames.data();
+		createInfo.pNext = &debugger.m_DebuggerCreateInfo;
+
+
+		if (debugger.isValidationEnabled())
+		{
+			createInfo.enabledLayerCount = debugger.getEnabledLayerCount();
+			createInfo.ppEnabledLayerNames = debugger.ptrToValidationLayers();
+		}
+		else
+		{
+			createInfo.enabledLayerCount = 0;
+			createInfo.ppEnabledLayerNames = nullptr;
+		}
+
+
+		//TODO: establish allocator callback for memory optimization purposes.
+		VkResult result = vkCreateInstance(&createInfo, nullptr, &m_Instance);
+
+		//TODO(Possible): implement into the event system! 
+		if (result == VK_SUCCESS)
+		{
+			std::cout << "Vulkan initialization successful!\n";
+		}
+	}
+
+
+
+	std::vector<VkExtensionProperties> v_Instance::getAvailableExtensions()
+	{
+		//TODO: edit first nullptr when validation layers are implemented
+		vkEnumerateInstanceExtensionProperties(nullptr, &m_AvailableExtensionCount, nullptr);
+
+		std::vector<VkExtensionProperties> extensionProperties(m_AvailableExtensionCount);
+		//get extension properties of ALL available extensions on our OS
+		vkEnumerateInstanceExtensionProperties(nullptr, &m_AvailableExtensionCount, extensionProperties.data());
+
+		return extensionProperties;
+	}
+
+
+	//stores names of Vulkan instance extensions 
+	std::vector<const char*> v_Instance::getRequiredExtensions(bool isDebuggerActive)
+	{
+		//+1 reserved for event of debugger usage; will be modified later in optimization
+		std::vector<const char*> extensionNames;
+
+		if (isDebuggerActive)
+		{
+			extensionNames.reserve(m_AvailableExtensionCount + 1);
+			extensionNames.emplace_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+		}
+		else
+		{
+			extensionNames.reserve(m_AvailableExtensionCount);
+		}
+
+		for (uint32_t i = 0; i < m_AvailableExtensionCount; i++)
+		{
+			const char* name = m_AvailableExtensions[i].extensionName;
+			extensionNames.emplace_back(name);
+		}
+		//use these for SDL_Vulkan_CreateSurface
+		WLFR_CORE_ASSERT(SDL_Vulkan_GetInstanceExtensions(&m_RequiredExtensionCount, m_RequiredExtensionNames.data()), "Failed to get required Vulkan extensions for SDL");
+
+
+		return extensionNames;
+
+		//identifies our required extensions for Vulkan to work with SDL	
+	}
+
+	void v_Instance::destroyInstance()
+	{
+		vkDestroyInstance(m_Instance, nullptr);
+	}
+}

--- a/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Instance/v_Instance.h
+++ b/WolfRenderer/WolfRenderer/src/renderer/Vulkan/v_Instance/v_Instance.h
@@ -1,0 +1,49 @@
+#pragma once
+
+
+
+#include <vulkan/vulkan.h>
+#include "../v_Debugger/v_Debugger.h"
+#include <condition_variable>
+
+
+
+namespace WolfRenderer
+{
+	class WLFR_API v_Instance
+	{
+
+	public:
+		v_Instance(v_Debugger& debugger, std::mutex& instanceCreationStatus,  std::condition_variable& instanceCreationSuccessful); 
+		~v_Instance();
+
+		VkInstance getInstance() const { return m_Instance; }
+
+		void destroyInstance();
+
+		//for sync with debugger
+		bool isInstanceCreated() const { return instanceCreated; }
+	private:
+		void createInstance(v_Debugger& debugger);
+
+	private:
+		VkInstance m_Instance;
+		VkApplicationInfo appInfo{};
+		bool instanceCreated = false; 
+		std::vector<VkExtensionProperties> m_AvailableExtensions;
+        //array of available extensions on our OS
+		std::vector<const char*> m_RequiredExtensionNames;
+
+		uint32_t m_AvailableExtensionCount;
+        //number of required extensions for Vulkan to function 
+		uint32_t m_RequiredExtensionCount;
+
+
+	private:
+		VkApplicationInfo inputApplcationInfo();
+		std::vector<VkExtensionProperties> getAvailableExtensions();
+		//populates our extension count and names
+		std::vector<const char*> getRequiredExtensions(bool isDebuggerActive);
+
+	};
+}


### PR DESCRIPTION
Begun (but not near complete) proofreading of naming convention status of Vulkan API abstraction; Removed static getInstance() function from Vulkan Singleton; Added v_Instance class to handle instance creation and begun synchonization implementation for debugger and instance to ensure proper order of functionality. TODO: Implement inputDebugMessengerInfo function outside of v_Instance constructor - functionality should be reserved for debugger class